### PR TITLE
Change "Get it" to "Use it"

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@ article {
   <h3> The happy little extendable markdown parser </h3>
 
   <div class='links'>
-    <a href='https://github.com/heyitsmeuralex/mrk'>Get it</a>
+    <a href='https://github.com/heyitsmeuralex/mrk'>Use it</a>
     |
     <a href='https://github.com/heyitsmeuralex/mrk/wiki'>Extensions</a>
   </div>


### PR DESCRIPTION
Bop it!

"Get it" sounds like mrk is something you buy; "use it" doesn't. (Also, the README reads "use it", so this makes the demo page consistent with that.)