### PR TITLE
Fix pattern for Autolinker

### DIFF
--- a/async.js
+++ b/async.js
@@ -32,15 +32,30 @@
               readUntil(c, orEnd = false) {
                 // Read until we encounter the character `c`
                 let buf = ''
-
+ 
                 for (let i = index; i < input.length; i++) {
-                  if (input[i] === c) {
-                    index += buf.length
+                    if(c.constructor === String) {
+                      if (input[i] === c) {
+                        index += buf.length
 
-                    return buf
-                  }
+                        return buf
+                      }
+                    } else if (c.constructor === Array) {
+                      if (c.includes(input[i])) {
+                        index += buf.length
 
-                  buf += input[i]
+                        return buf
+                      }
+                    } else if (c.constructor === RegExp) {
+                      if (c.test(input[i])) {
+                        index += buf.length
+
+                        return buf
+                      }
+                    } else {
+                      throw "Firt argument to readUntil must be of type String, Array, or RegExp"
+                    }
+                    buf += input[i]
                 }
 
                 if (orEnd) {

--- a/async.js
+++ b/async.js
@@ -282,8 +282,8 @@
         if (read(1) !== 's') rewind(1)
         if (read(3) !== '://') return
 
-        // Eat everything until a space; we can assume that this is a valid URL
-        readUntil(' ', true)
+        // Eat everything until a whitespace; we can assume that this is a valid URL
+        readUntil(/\s/, true)
 
         return true
       },

--- a/mrk.js
+++ b/mrk.js
@@ -29,28 +29,28 @@
                 let buf = ''
  
                 for (let i = index; i < input.length; i++) {
-                    if(c instanceof String) {
+                    if(c.constructor === String) {
                       if (input[i] === c) {
                         index += buf.length
 
                         return buf
                       }
-                    } else if (c instanceof Array) {
+                    } else if (c.constructor === Array) {
                       if (c.includes(input[i])) {
                         index += buf.length
 
                         return buf
                       }
-                    } else {                      
+                    } else if (c.constructor === RegExp) {
                       if (c.test(input[i])) {
                         index += buf.length
 
                         return buf
                       }
+                    } else {
+                      throw "Firt argument to readUntil must be of type String, Array, or RegExp"
                     }
-                  }
-
-                  buf += input[i]
+                    buf += input[i]
                 }
 
                 if (orEnd) {

--- a/mrk.js
+++ b/mrk.js
@@ -27,12 +27,27 @@
               readUntil(c, orEnd = false) {
                 // Read until we encounter the character `c`
                 let buf = ''
-
+ 
                 for (let i = index; i < input.length; i++) {
-                  if (input[i] === c) {
-                    index += buf.length
+                    if(c instanceof String) {
+                      if (input[i] === c) {
+                        index += buf.length
 
-                    return buf
+                        return buf
+                      }
+                    } else if (c instanceof Array) {
+                      if (c.includes(input[i])) {
+                        index += buf.length
+
+                        return buf
+                      }
+                    } else {                      
+                      if (c.test(input[i])) {
+                        index += buf.length
+
+                        return buf
+                      }
+                    }
                   }
 
                   buf += input[i]

--- a/mrk.js
+++ b/mrk.js
@@ -290,8 +290,8 @@
         if (read(1) !== 's') rewind(1)
         if (read(3) !== '://') return
 
-        // Eat everything until a space; we can assume that this is a valid URL
-        readUntil(' ', true)
+        // Eat everything until a whitespace; we can assume that this is a valid URL
+        readUntil(/\s/, true)
 
         return true
       },


### PR DESCRIPTION
This pull request fixes #1.

# Changes
 - `readUntil()` now supports the types: `Array`, `String`, and `RegExp`, but each can only match one character
   - Passing an `Array` will match a character if it is included in the array
   - Passing a `String` will match a character if it is equal to the string
   - Passing a `RegExp` will match a character if it passes the regular expression (`.test() // == true`)

 - the autolink feature now matches until the first `/\s/` rather than the first `' '`
 - changed in
   - mrk.js
   - async.js

# Testing

This pull request wasn't fully tested, but I _did_ test the `readUntil` function and it worked flawlessly. The rest of the changes were minor so I'm hoping I didn't break anything.